### PR TITLE
Allowing easy-install plugin with shell script and providing an user-friendly README.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+## How to contribute
+
+1. If you're a student at NEMO/UFES working at this project, ask the repository administrators to give you developer access;
+
+2. Go to the [project's issues](https://github.com/nemo-ufes/frameweb-vp-plugin/issues) click one of the open issues and assign it to yourself;
+
+3. On the right-hand side of the issue page, look for the **Development** section, click on the _Create a branch_ link and create the branch;
+
+4. Use the instructions shown by GitHub (`git fetch origin` and `git checkout <branch-name>`) in your local computer to switch to the newly created branch;
+
+5. Work on that branch to resolve the issue at hand. Make as many commits as you want, you can push them to GitHub too;
+
+6. Once you finish (make sure you pushed all your commits), open your branch on GitHub (after it's created, GitHub places a link to it under the **Development** section mentioned earlier), see the information that the branch is ahead of main, click on the _Contribute_ button and select _Open Pull Request_;
+
+7. In the body of the pull request (_Leave a comment_ field), add a [closing keyword](https://docs.github.com/articles/closing-issues-using-keywords) referring to the ID of the issue you are resolving. For instance, if it's issue #1, you can write `Closes #1`. If needed, include other information in the body of the pull request (write as much as you need). Finally, click on _Create Pull Request_;
+
+8. On the right-hand side of the pull request page, under **Assignees**, assign it to yourself;
+
+9. Also on the right-hand side, under **Reviewers**, assign a reviewer to the pull request according to what has been agreed with the other developers and the repository administrators;
+
+10. Wait for the code review comments, work on the code if needed, until the pull request is approved. At this point, click on _Merge pull request_ to merge your changes into the main branch;
+
+11. Finally, go back to the main branch in your local computer (`git checkout main`) and update it to get the changes that were merged by the pull request on GitHub (`git pull origin`).
+
+Move on to the next issue and repeat the cycle.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ bash <(curl -sL https://raw.githubusercontent.com/propilideno/frameweb-vp-plugin
 ```
 ### Manual:
 Open `pom.xml`, and:
-- Edit: `<!-- APP_PATH -->` to the **PATH** to your Visual Paradigm's **Application Folder**.
-- Edit: `<!-- PLUGIN_PATH -->` to the **PATH** to your Visual Paradigm's **Plugin Folder**.
+- Edit: `<!-- APP_PATH -->` to the **PATH** of your Visual Paradigm's **Application Folder**.
+- Edit: `<!-- PLUGIN_PATH -->` to the **PATH** of your Visual Paradigm's **Plugin Folder**.
 ```
     <visualparadigm.app.dir>
       <!-- APP_PATH -->
@@ -43,4 +43,5 @@ This plug-in is under development, improvements can always be made!
 - [ ] Generate code for the Entity Model
 - [x] Release a stable FrameWeb Plugin for Visual Paradigm
 - [x] Automatically install FrameWeb Plugin and your dependencies with Shell Script.
+
 Please read our [contributing guidelines](CONTRIBUTING.md) for more detailed information.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This plug-in is under development, once it becomes ready for production use (or 
 - Git Bash: https://git-scm.com/downloads
 
 ## Installing
-
 - **Ubuntu/Mac**, open the `Terminal` and type:
 ```
 chmod +x install.sh && ./install.sh
@@ -19,6 +18,10 @@ chmod +x install.sh && ./install.sh
 - **Windows**, open the `Git Bash` and type:
 ```
 chmod +x install.sh && ./install.sh
+```
+- **EXPERIMENTAL**, one installation with one command:
+```
+bash <(curl -sL https://raw.githubusercontent.com/propilideno/frameweb-vp-plugin/main/install.sh)
 ```
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This plug-in is under development, once it becomes ready for production use (or 
 chmod +x install.sh
 ./install.sh
 ```
-**Windows**, double click on **install.sh** :
-```
-./install.sh
-```
+**Windows**:
+1. Right Click on `install.sh`
+2. Click on `properties`
+3. Allow your execution and save
 
 ### Testing
 Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar.

--- a/README.md
+++ b/README.md
@@ -8,49 +8,25 @@ This plug-in is under development, once it becomes ready for production use (or 
 
 At this point, the project may require some knowledge of software development in Java with Maven to be used. 
 
+### Requirements
+1. JDK (11+): https://www.oracle.com/br/java/technologies/downloads/
+2. Maven: https://maven.apache.org/download.cgi
+3. Visual Paradigm: https://www.visual-paradigm.com/download/
 
-### How to install and test the plug-in
+### Quickstart
 
-1. Have Maven and the Java (11+) Development Kit installed in your computer;
-
-2. Install [Visual Paradigm](https://www.visual-paradigm.com/download/) (the [Community Edition](https://www.visual-paradigm.com/download/community.jsp) is free for non-commercial use);
-
-3. Clone this repository;
-
-4. Open `pom.xml` and set the value of the variables listed below:
-
-    4.1. Set the path to the folder in which the Visual Paradigm application is located, e.g.:
-
-    ```xml
-    <visualparadigm.app.dir>
-       /Applications/Visual Paradigm.app/Contents/Resources/app/
-    </visualparadigm.app.dir>
-    ```
-
-    This path is typically:
-
-    * On Linux: ???
-    * On MacOS: `/Applications/Visual Paradigm.app/Contents/Resources/app/`
-    * On Windows: `C:\Program Files\Visual Paradigm CE 17.0`
-
-   4.2. Set the path to Visual Paradigm's plugin folder, e.g.:
-
-   ```xml
-    <visualparadigm.plugin.dir>
-        /Users/vitor/Library/Application Support/VisualParadigm/plugins
-    </visualparadigm.plugin.dir>
-    ```
-
-    This path is typically:
-
-    * On Linux: `/home/<YOUR_USER_NAME>/.config/VisualParadigm/plugins/`
-    * On MacOS: `/Users/<YOUR_USER_NAME>/Library/Application Support/VisualParadigm/plugins/`
-    * On Windows: `C:\Users\<YOUR_USER_NAME>\AppData\Roaming\VisualParadigm\plugins\`
-
-5. With Visual Paradigm closed, run `mvn install`;
-
-6. Open Visual Paradigm. Check if there is a _Plugin_ tab in the toolbar.
-
+**Ubuntu/Mac**, open the terminal and type:
+```
+chmod +x install.sh
+./install.sh
+```
+**Windows**, double click on **install.sh** :
+```
+./install.sh
+```
+### Testing
+Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar.
+If the installation was successfull, you can learn how to use in [FrameWeb Repository](https://github.com/nemo-ufes/FrameWeb).
 
 ### How to contribute
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plug-in is under development, once it becomes ready for production use (or 
 
 ### Quickstart
 
+
 **Ubuntu/Mac**, open the terminal and type:
 ```
 chmod +x install.sh
@@ -18,15 +19,16 @@ chmod +x install.sh
 ```
 ./install.sh
 ```
+
 ### Testing
 Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar.
 If the installation was successfull, you can learn how to use in [FrameWeb Repository](https://github.com/nemo-ufes/FrameWeb).
 
-### Contributing and Ways to Improve
+### Releases
 - [x] Release a stable FrameWeb Plugin for Visual Paradigm
 - [ ] Automatically install FrameWeb Plugin dependencies with Shell Script.
 
-### How to contribute
+### Fixing Issues
 
 1. If you're a student at NEMO/UFES working at this project, ask the repository administrators to give you developer access;
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,8 @@ This plug-in is under development, once it becomes ready for production use (or 
 - Git Bash: https://git-scm.com/downloads
 
 ## Installing
-- **Ubuntu/Mac**, open the `Terminal` and type:
-```
-chmod +x install.sh && ./install.sh
-```
-- **Windows**, open the `Git Bash` and type:
-```
-chmod +x install.sh && ./install.sh
-```
-- **EXPERIMENTAL**, full installation with one command:
+- **Windows**, open `Git Bash`,
+- **Linux|MacOS**, open `Terminal` and type:
 ```
 bash <(curl -sL https://raw.githubusercontent.com/propilideno/frameweb-vp-plugin/main/install.sh)
 ```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This plug-in is under development, once it becomes ready for production use (or almost) a better README file should be provided.
 
-
-
-## Instructions for developers
-
-At this point, the project may require some knowledge of software development in Java with Maven to be used. 
-
 ### Requirements
 1. JDK (11+): https://www.oracle.com/br/java/technologies/downloads/
 2. Maven: https://maven.apache.org/download.cgi
@@ -27,6 +21,10 @@ chmod +x install.sh
 ### Testing
 Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar.
 If the installation was successfull, you can learn how to use in [FrameWeb Repository](https://github.com/nemo-ufes/FrameWeb).
+
+### Contributing and Ways to Improve
+- [x] Release a stable FrameWeb Plugin for Visual Paradigm
+- [ ] Automatically install FrameWeb Plugin dependencies with Shell Script.
 
 ### How to contribute
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ chmod +x install.sh && ./install.sh
 ```
 chmod +x install.sh && ./install.sh
 ```
-- **EXPERIMENTAL**, one installation with one command:
+- **EXPERIMENTAL**, full installation with one command:
 ```
 bash <(curl -sL https://raw.githubusercontent.com/propilideno/frameweb-vp-plugin/main/install.sh)
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # FrameWeb Plugin for Visual Paradigm
-
-This plug-in is under development, once it becomes ready for production use (or almost) a better README file should be provided.
+Our team is currently developing a plugin that will enable integration between [The FrameWeb Method](https://github.com/nemo-ufes/FrameWeb/wiki) and Visual Paradigm. With our easy-to-install plugin, you can quickly create FrameWeb models within the Visual Paradigm environment allowing code generation for web applications that comply with FrameWeb's conventions and best practices.
 
 ## Requirements
 1. JDK (11+): https://www.oracle.com/br/java/technologies/downloads/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plug-in is under development, once it becomes ready for production use (or almost) a better README file should be provided.
 
-### Requirements:
+## Requirements
 1. JDK (11+): https://www.oracle.com/br/java/technologies/downloads/
 2. Maven: https://maven.apache.org/download.cgi
 3. Visual Paradigm: https://www.visual-paradigm.com/download/
@@ -10,27 +10,29 @@ This plug-in is under development, once it becomes ready for production use (or 
 **Only for Windows Users**:
 - Git Bash: https://git-scm.com/downloads
 
-### Quickstart:
+## Installing
 
-
-**Ubuntu/Mac**, open the `Terminal` and type:
+- **Ubuntu/Mac**, open the `Terminal` and type:
 ```
 chmod +x install.sh && ./install.sh
 ```
-**Windows**, open the `Git Bash` and type:
+- **Windows**, open the `Git Bash` and type:
 ```
 chmod +x install.sh && ./install.sh
 ```
 
-### Testing
-Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar.
+## Quickstart
+Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar. <br>
 If the installation was successfull, you can learn how to use in [FrameWeb Repository](https://github.com/nemo-ufes/FrameWeb).
 
-### Releases
+## Releases
 - [x] Release a stable FrameWeb Plugin for Visual Paradigm
-- [ ] Automatically install FrameWeb Plugin dependencies with Shell Script.
+- [x] Automatically install FrameWeb Plugin and your dependencies with Shell Script.
+- [ ] Allow the designer to add new templates for code generation
+- [ ] Allow the designer to choose the templates to use in code generation
+- [ ] Generate code for the Entity Model
 
-### Contributing with us fixing Issues
+## Contributing with us fixing Issues
 
 1. If you're a student at NEMO/UFES working at this project, ask the repository administrators to give you developer access;
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If the installation was successfull, you can learn how to use in [FrameWeb Repos
 - [x] Release a stable FrameWeb Plugin for Visual Paradigm
 - [ ] Automatically install FrameWeb Plugin dependencies with Shell Script.
 
-### Fixing Issues
+### Contributing with us fixing Issues
 
 1. If you're a student at NEMO/UFES working at this project, ask the repository administrators to give you developer access;
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,9 @@ This plug-in is under development, once it becomes ready for production use (or 
 
 **Ubuntu/Mac**, open the terminal and type:
 ```
-chmod +x install.sh
-./install.sh
+chmod +x install.sh && ./install.sh
 ```
-**Windows**:
-1. Right Click on `install.sh`
-2. Click on `properties`
-3. Allow your execution and save
+**Windows**: Under development
 
 ### Testing
 Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,25 @@
 
 This plug-in is under development, once it becomes ready for production use (or almost) a better README file should be provided.
 
-### Requirements
+### Requirements:
 1. JDK (11+): https://www.oracle.com/br/java/technologies/downloads/
 2. Maven: https://maven.apache.org/download.cgi
 3. Visual Paradigm: https://www.visual-paradigm.com/download/
 
-### Quickstart
+**Only for Windows Users**:
+- Git Bash: https://git-scm.com/downloads
+
+### Quickstart:
 
 
-**Ubuntu/Mac**, open the terminal and type:
+**Ubuntu/Mac**, open the `Terminal` and type:
 ```
 chmod +x install.sh && ./install.sh
 ```
-**Windows**: Under development
+**Windows**, open the `Git Bash` and type:
+```
+chmod +x install.sh && ./install.sh
+```
 
 ### Testing
 Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar.

--- a/README.md
+++ b/README.md
@@ -10,46 +10,37 @@ This plug-in is under development, once it becomes ready for production use (or 
 **Only for Windows Users**:
 - Git Bash: https://git-scm.com/downloads
 
-## Installing
-- **Windows**, open `Git Bash`,
-- **Linux|MacOS**, open `Terminal` and type:
+## Installation
+### Automatic:
+- **Windows**, open `Git Bash` ;
+- **Linux / MacOS**, open `Terminal` and type:
 ```
 bash <(curl -sL https://raw.githubusercontent.com/propilideno/frameweb-vp-plugin/main/install.sh)
 ```
+### Manual:
+Open `pom.xml`, and:
+- Edit: `<!-- APP_PATH -->` to the **PATH** to your Visual Paradigm's **Application Folder**.
+- Edit: `<!-- PLUGIN_PATH -->` to the **PATH** to your Visual Paradigm's **Plugin Folder**.
+```
+    <visualparadigm.app.dir>
+      <!-- APP_PATH -->
+    </visualparadigm.app.dir>
+
+    <visualparadigm.plugin.dir>
+      <!-- PLUGIN_PATH -->
+    </visualparadigm.plugin.dir>
+```
+After edittings, run: `mvn install`.
 
 ## Quickstart
 Open Visual Paradigm and check if there is a _Plugin_ tab in the toolbar. <br>
 If the installation was successfull, you can learn how to use in [FrameWeb Repository](https://github.com/nemo-ufes/FrameWeb).
 
-## Releases
-- [x] Release a stable FrameWeb Plugin for Visual Paradigm
-- [x] Automatically install FrameWeb Plugin and your dependencies with Shell Script.
+## Contributing & Ways to improve
+This plug-in is under development, improvements can always be made!
 - [ ] Allow the designer to add new templates for code generation
 - [ ] Allow the designer to choose the templates to use in code generation
 - [ ] Generate code for the Entity Model
-
-## Contributing with us fixing Issues
-
-1. If you're a student at NEMO/UFES working at this project, ask the repository administrators to give you developer access;
-
-2. Go to the [project's issues](https://github.com/nemo-ufes/frameweb-vp-plugin/issues) click one of the open issues and assign it to yourself;
-
-3. On the right-hand side of the issue page, look for the **Development** section, click on the _Create a branch_ link and create the branch;
-
-4. Use the instructions shown by GitHub (`git fetch origin` and `git checkout <branch-name>`) in your local computer to switch to the newly created branch;
-
-5. Work on that branch to resolve the issue at hand. Make as many commits as you want, you can push them to GitHub too;
-
-6. Once you finish (make sure you pushed all your commits), open your branch on GitHub (after it's created, GitHub places a link to it under the **Development** section mentioned earlier), see the information that the branch is ahead of main, click on the _Contribute_ button and select _Open Pull Request_;
-
-7. In the body of the pull request (_Leave a comment_ field), add a [closing keyword](https://docs.github.com/articles/closing-issues-using-keywords) referring to the ID of the issue you are resolving. For instance, if it's issue #1, you can write `Closes #1`. If needed, include other information in the body of the pull request (write as much as you need). Finally, click on _Create Pull Request_;
-
-8. On the right-hand side of the pull request page, under **Assignees**, assign it to yourself;
-
-9. Also on the right-hand side, under **Reviewers**, assign a reviewer to the pull request according to what has been agreed with the other developers and the repository administrators;
-
-10. Wait for the code review comments, work on the code if needed, until the pull request is approved. At this point, click on _Merge pull request_ to merge your changes into the main branch;
-
-11. Finally, go back to the main branch in your local computer (`git checkout main`) and update it to get the changes that were merged by the pull request on GitHub (`git pull origin`).
-
-Move on to the next issue and repeat the cycle.
+- [x] Release a stable FrameWeb Plugin for Visual Paradigm
+- [x] Automatically install FrameWeb Plugin and your dependencies with Shell Script.
+Please read our [contributing guidelines](CONTRIBUTING.md) for more detailed information.

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,7 @@ function get_VP_App_Path(){
                 esac
             done
             app_dir=$VISUAL_PARADIGM_APP_DIR_WINDOWS
+            app_dir=$(echo "$app_dir" | sed 's/\\/\\\\/g')
         ;;
         *)
             echo "Operating System not Supported"
@@ -122,6 +123,7 @@ function get_VP_Plugin_Path(){
                 esac
             done
             plugin_dir=$VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS
+            plugin_dir=$(echo "$plugin_dir" | sed 's/\\/\\\\/g')
         ;;
         *)
             echo "Operating System not Supported"

--- a/install.sh
+++ b/install.sh
@@ -227,7 +227,7 @@ function install_frameweb_vp_plugin(){
         done
     fi
     # Config pom.xml with gathered paths
-    case "$os" in 
+    case "$OS" in 
         Darwin*) 
             sed -i '' "s|<!-- APP_PATH -->|$app_dir|g" pom.xml # '' Before the regex is to prevent ISSUE on MacOS.
             sed -i '' "s|<!-- PLUGIN_PATH -->|$plugin_dir|g" pom.xml # '' Before the regex is to prevent ISSUE on MacOS

--- a/install.sh
+++ b/install.sh
@@ -43,34 +43,36 @@ function get_VP_App_Path(){
                 echo "Visual Paradigm Path: $VISUAL_PARADIGM_APP_DIR_MAC"
                 read -p "Confirm (y/n)?" choice
                 case "$choice" in
-                    y|Y ) break;;
+                    y|Y ) 
+                        if [[ -d $VISUAL_PARADIGM_APP_DIR_MAC ]]; then
+                            break
+                        else
+                            printf "<FOLDER NOT FOUND> Type a valid path!\n"
+                        fi
+                    ;;
                     n|N ) read -p "The path to your Visual Paradigm (APP FOLDER) is: " VISUAL_PARADIGM_APP_DIR_MAC ;;
                     * ) printf "Invalid input\n";;
                 esac
-                if [[ -d $VISUAL_PARADIGM_APP_DIR_MAC ]]; then
-                    break
-                else
-                    printf "<FOLDER NOT FOUND> Type a valid path!\n"
-                fi
             done
-            echo $VISUAL_PARADIGM_APP_DIR_MAC
+            app_dir=$VISUAL_PARADIGM_APP_DIR_MAC
         ;;
-        CYGWIN*)
+        MINGW64*)
             while true; do
                 echo "Visual Paradigm Path: $VISUAL_PARADIGM_APP_DIR_WINDOWS"
                 read -p "Confirm (y/n)?" choice
                 case "$choice" in
-                    y|Y ) break;;
+                    y|Y ) 
+                        if [[ -d $VISUAL_PARADIGM_APP_DIR_WINDOWS ]]; then
+                            break
+                        else
+                            printf "<FOLDER NOT FOUND> Type a valid path!\n"
+                        fi
+                    ;;
                     n|N ) read -p "The path to your Visual Paradigm (APP FOLDER) is: " VISUAL_PARADIGM_APP_DIR_WINDOWS ;;
                     * ) printf "Invalid input\n";;
                 esac
-                if [[ -d $VISUAL_PARADIGM_APP_DIR_WINDOWS ]]; then
-                    break
-                else
-                    printf "<FOLDER NOT FOUND> Type a valid path!\n"
-                fi
             done
-            echo $VISUAL_PARADIGM_APP_DIR_WINDOWS
+            app_dir=$VISUAL_PARADIGM_APP_DIR_WINDOWS
         ;;
         *)
             echo "Operating System not Supported"
@@ -98,30 +100,27 @@ function get_VP_Plugin_Path(){
         ;;
         Darwin*)
             while true; do
-                echo "Visual Paradigm Plugin Path: $(VISUAL_PARADIGM_PLUGIN_DIR_LINUX)" 
+                echo "Visual Paradigm Plugin Path: $VISUAL_PARADIGM_PLUGIN_DIR_MAC"
                 read -p "Confirm (y/n)?" choice
                 case "$choice" in
                     y|Y ) break;;
-                    n|N ) read -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_LINUX ;;
+                    n|N ) read -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_MAC ;;
                     * ) printf "Invalid input\n";;
                 esac
             done
-            echo $VISUAL_PARADIGM_PLUGIN_DIR_LINUX # Return Value
+            plugin_dir=$VISUAL_PARADIGM_PLUGIN_DIR_MAC
         ;;
-        CYGWIN*)
+        MINGW64*)
             while true; do
-                echo "Visual Paradigm Plugin Path: $VISUAL_PARADIGM_PLUGIN_DIR_LINUX" 
-                read -p "Confirm (y/n)?" $answer
-                if [ "$answer" == "y" ]; then
-                    break
-                else
-                    if [[ ! -d $VISUAL_PARADIGM_PLUGIN_DIR_LINUX ]]; then
-                        printf "<FOLDER NOT FOUND> Type a valid path!\n"
-                        read -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_LINUX
-                    fi
-                fi
+                echo "Visual Paradigm Plugin Path: $VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS"
+                read -p "Confirm (y/n)?" choice
+                case "$choice" in
+                    y|Y ) break;;
+                    n|N ) read -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS ;;
+                    * ) printf "Invalid input\n";;
+                esac
             done
-            echo $VISUAL_PARADIGM_PLUGIN_DIR_LINUX # Return Value
+            plugin_dir=$VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS
         ;;
         *)
             echo "Operating System not Supported"
@@ -153,8 +152,8 @@ function install_maven(){
         elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
             # Instalação no Linux
             sudo apt-get install maven
-        elif [[ "$OSTYPE" == "cygwin" ]]; then
-            # Instalação no Windows usando Cygwin
+        elif [[ "$OSTYPE" == "MINGW64" ]]; then
+            # Instalação no Windows
             echo "Not supported yet"
             exit 1
         else
@@ -175,7 +174,7 @@ function install_jdk(){
         elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
             # Instalação no Linux
             sudo apt-get install default-jdk
-        elif [[ "$OSTYPE" == "cygwin" ]]; then
+        elif [[ "$OSTYPE" == "MINGW64" ]]; then
             # Instalação no Windows
             echo "Not supported yet"
             exit 1

--- a/install.sh
+++ b/install.sh
@@ -270,13 +270,18 @@ function install_brew(){
 
 # Function to install for debian based distrOS (and ubuntu)
 function install_shell_deps(){ 
-    if [[ "$OS" == "Darwin*" ]]; then
-        # Instalação no Mac
-        install_brew
-    elif [[ "$OS" == "Linux*" ]]; then
-        # Instalação no Linux
-        sudo apt-get install unzip
-    fi
+    case "$OS" in 
+        Darwin*) 
+			# Mac Installation
+			install_brew
+            ;;
+        Linux*)
+			# Linux Installation
+			sudo apt-get install unzip	
+			;;
+		*)
+			echo "No shell requirements for your SO"
+    esac
 }
 
 function clean_installation(){

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-os=$(uname -s) # Gather OS Name
+OS=$(uname -s) # Gather OS Name
+USER=$(whoami) # Gather USER Name
 
 function readPath(){ #UNDER DEVELOPMENT
     while true; do
@@ -19,7 +20,7 @@ function get_VP_App_Path(){
     local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\"
     local VISUAL_PARADIGM_APP_DIR_MAC="/Applications/Visual Paradigm.app/Contents/Resources/app/"
     local VISUAL_PARADIGM_APP_DIR_LINUX="/home/$USER/Visual_Paradigm_17.0/"
-    case "$os" in
+    case "$OS" in
         Linux*)  
             while true; do
                 echo "Visual Paradigm Path: $VISUAL_PARADIGM_APP_DIR_LINUX"
@@ -59,7 +60,7 @@ function get_VP_App_Path(){
         MINGW64*)
             while true; do
                 echo "Visual Paradigm Path: $VISUAL_PARADIGM_APP_DIR_WINDOWS"
-                read -p "Confirm (y/n)?" choice
+                read -r -p "Confirm (y/n)?" choice
                 case "$choice" in
                     y|Y ) 
                         if [[ -d $VISUAL_PARADIGM_APP_DIR_WINDOWS ]]; then
@@ -68,7 +69,7 @@ function get_VP_App_Path(){
                             printf "<FOLDER NOT FOUND> Type a valid path!\n"
                         fi
                     ;;
-                    n|N ) read -p "The path to your Visual Paradigm (APP FOLDER) is: " VISUAL_PARADIGM_APP_DIR_WINDOWS ;;
+                    n|N ) read -r -p "The path to your Visual Paradigm (APP FOLDER) is: " VISUAL_PARADIGM_APP_DIR_WINDOWS ;;
                     * ) printf "Invalid input\n";;
                 esac
             done
@@ -82,10 +83,10 @@ function get_VP_App_Path(){
 
 function get_VP_Plugin_Path(){
     #Plugin Default Path
-    local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS="C:\\Users\\%USERNAME%\\AppData\\Roaming\\VisualParadigm\\plugins\\" #Windows
+    local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS="C:\\Users\\$USER\\AppData\\Roaming\\VisualParadigm\\plugins\\" #Windows
     local VISUAL_PARADIGM_PLUGIN_DIR_MAC="/Users/$USER/Library/Application Support/VisualParadigm/plugins/" #UNIX
     local VISUAL_PARADIGM_PLUGIN_DIR_LINUX="/home/$USER/.config/VisualParadigm/plugins/" #UNIX
-    case "$os" in
+    case "$OS" in
         Linux*)  
             while true; do
                 echo "Visual Paradigm Plugin Path: $VISUAL_PARADIGM_PLUGIN_DIR_LINUX"
@@ -116,7 +117,7 @@ function get_VP_Plugin_Path(){
                 read -p "Confirm (y/n)?" choice
                 case "$choice" in
                     y|Y ) break;;
-                    n|N ) read -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS ;;
+                    n|N ) read -r -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS ;;
                     * ) printf "Invalid input\n";;
                 esac
             done
@@ -145,21 +146,21 @@ function install_maven(){
     if command -v mvn &> /dev/null; then
         echo "Maven already installed."
     else
-        # Instalação de dependências
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            # Instalação no Mac
-            brew install maven
-        elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-            # Instalação no Linux
-            sudo apt-get install maven
-        elif [[ "$OSTYPE" == "MINGW64" ]]; then
-            # Instalação no Windows
-            echo "Not supported yet"
+        case "$OS" in
+            Linux*)
+                sudo apt-get install maven
+            ;;
+            Darwin*)
+                # Instalação no Mac
+                brew install maven
+            ;;
+            MINGW64*)
+                echo "Installing Maven in Windows ..."
+            ;;
+        *)
+            echo "Operating System not Supported"
             exit 1
-        else
-            echo "Sistema operacional não suportado"
-            exit 1
-        fi
+        esac
     fi
 }
 
@@ -167,21 +168,21 @@ function install_jdk(){
     if command -v javac &> /dev/null; then
         echo "JDK already installed."
     else
-        # Instalação de dependências
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            # Instalação no Mac
-            brew install java
-        elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-            # Instalação no Linux
-            sudo apt-get install default-jdk
-        elif [[ "$OSTYPE" == "MINGW64" ]]; then
-            # Instalação no Windows
-            echo "Not supported yet"
+        case "$OS" in
+            Linux*)
+                sudo apt-get install default-jdk 
+            ;;
+            Darwin*)
+                # Instalação no Mac
+                brew install java
+            ;;
+            MINGW64*)
+                echo "Installing Maven in Windows ..."
+            ;;
+        *)
+            echo "Operating System not Supported"
             exit 1
-        else
-            echo "Sistema operacional não suportado"
-            exit 1
-        fi
+        esac
     fi
 }
 
@@ -228,7 +229,7 @@ function install_brew(){
     fi
 }
 
-# Function to install for debian based distros (and ubuntu)
+# Function to install for debian based distrOS (and ubuntu)
 function install_shell_deps(){ 
     if [[ "$OSTYPE" == "darwin"* ]]; then
         # Instalação no Mac

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,172 @@
+#!/bin/bash 
+
+function defineVPPath(){
+    #Windows path
+    local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\"
+    #MacOS path
+    local VISUAL_PARADIGM_APP_DIR_MAC= "/Applications/Visual Paradigm.app"
+    #Linux path
+    local VISUAL_PARADIGM_APP_DIR_DEBIAN= ""
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        return $VISUAL_PARADIGM_APP_DIR_MAC
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        return $VISUAL_PARADIGM_APP_DIR_LINUX
+    elif [[ "$OSTYPE" == "cygwin" ]]; then
+        return $VISUAL_PARADIGM_APP_DIR_WINDOWS
+}
+
+function definePluginPath(){
+    #Windows path
+    local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS= "C:\\Users\\%USERNAME%\\AppData\\Roaming\\VisualParadigm\\plugins\\"
+    #MacOS path
+    local VISUAL_PARADIGM_PLUGIN_DIR_MAC= "/Users/$USER/Library/Application Support/VisualParadigm/plugins/"
+    #Linux path
+    local VISUAL_PARADIGM_PLUGIN_DIR_DEBIAN= "/home/$USER/.config/VisualParadigm/plugins/"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        return $VISUAL_PARADIGM_PLUGIN_DIR_MAC
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        return $VISUAL_PARADIGM_PLUGIN_DIR_LINUX
+    elif [[ "$OSTYPE" == "cygwin" ]]; then
+        return $VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS
+}
+
+
+# If the install fails, then print an error and exit.
+function install_fail() {
+    echo "Installation failed" 
+    exit 1 
+} 
+
+# This is the help fuction. It helps users withe the options
+function Help(){ 
+    echo "Usage: ./install.sh" 
+    echo "Make sure u have permission to execute install.sh"
+    echo "If u had problems try it: "chmod +x install.sh" or allow execution in properties"
+}
+
+function install_maven(){
+    if command -v mvn &> /dev/null; then
+        echo "Maven already installed."
+        exit 1
+    else
+        # Instalação de dependências
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            # Instalação no Mac
+            brew install maven
+        elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # Instalação no Linux
+            sudo apt-get install maven
+        elif [[ "$OSTYPE" == "cygwin" ]]; then
+            # Instalação no Windows usando Cygwin
+            echo "Not supported yet"
+        else
+            echo "Sistema operacional não suportado"
+            exit 1
+        fi
+    fi
+}
+
+function install_jdk(){
+    if command -v javac &> /dev/null; then
+        echo "JDK already installed."
+        exit 1
+    else
+        # Instalação de dependências
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            # Instalação no Mac
+            brew install java
+        elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # Instalação no Linux
+            sudo apt-get install maven
+        elif [[ "$OSTYPE" == "cygwin" ]]; then
+            # Instalação no Windows
+            echo "Not supported yet"
+        else
+            echo "Sistema operacional não suportado"
+            exit 1
+        fi
+    fi
+}
+
+function install_jdk(){
+    echo "Instalando JDK ..."
+    if command -v javac &> /dev/null; then
+        echo "JDK already installed."
+    else
+        brew install openjdk
+        if ! command -v javac &> /dev/null; then
+            echo "O JDK não foi instalado corretamente. Verifique se há erros acima."
+            exit 1
+        fi
+        echo "O JDK foi instalado com sucesso."
+    fi
+}
+
+function install_frameweb_vp_plugin(){
+    # Instala o plugin com o maven
+    mvn install
+    # Verificar se o plugin foi instalado com sucesso
+    if [ -d "/Users/$USER/Library/Application Support/VisualParadigm/plugins" ]; then
+        echo "O plugin foi instalado com sucesso."
+    else
+        echo "A instalação do plugin falhou."
+        exit 1
+    fi
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # Instalação no Mac
+        install_brew
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        # Instalação no Linux
+    fi
+}
+
+function install_visual_paradigm(){
+    echo "Opening Visual Paradigm WebSite"
+    open https://www.visual-paradigm.com/download/
+}
+
+function install_brew(){
+    # Check if homebrew is installed
+    if [ ! command -v brew &> /dev/null ]; then
+        echo "Installing Homebrew ..."
+        # if it's is not installed, then install it.
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)" 
+        # Check for what arcitecture, so you can place path.
+        if [[ "uname -m" == "x86_64" ]]; then
+            echo "export PATH=/usr/local/bin:$PATH" >> ~/.bash_profile && source ~/.bash_profile
+        fi
+    # If not
+    else
+        # Print that it's already installed
+        echo "Homebrew is already installed"
+    fi
+}
+
+# Function to install for debian based distros (and ubuntu)
+function install_shell_deps(){ 
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # Instalação no Mac
+        install_brew
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        # Instalação no Linux
+    fi
+} 
+
+# Main function
+function install_main(){ 
+    #Defining the path
+
+    echo "=== Frameweb-vp-plugin Installer ==="
+    echo "Installing shell dependencies ..."
+    install_shell_deps
+    echo "Installing plugin dependencies ..."
+    install_jdk
+    install_maven
+    install_visual_paradigm
+    echo "Installing frameweb-vp-plugin..."
+    install_frameweb_vp_plugin 
+}
+
+# Run the main function
+install_main

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,20 @@
 OS=$(uname -s) # Gather OS Name
 USER=$(whoami) # Gather USER Name
 
-#FrameWeb Defaults
+#FrameWeb-Vp-Plugin Defaults
 repo_name="frameweb-vp-plugin"
 repo_url="https://github.com/propilideno/frameweb-vp-plugin/archive/refs/heads/main.zip"
+frameweb_plugin_path="frameweb-vp-plugin-0.1/"
 
+# =========== Visual Paradigm Defaults ===========
+#App Default Path
+VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\" #Windows
+VISUAL_PARADIGM_APP_DIR_MAC="/Applications/Visual Paradigm.app/Contents/Resources/app/" #MacOS
+VISUAL_PARADIGM_APP_DIR_LINUX="/home/$USER/Visual_Paradigm_17.0/" #Linux
+#Plugin Default Path
+VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS="C:\\Users\\$USER\\AppData\\Roaming\\VisualParadigm\\plugins\\" #Windows
+VISUAL_PARADIGM_PLUGIN_DIR_MAC="/Users/$USER/Library/Application Support/VisualParadigm/plugins/" #MacOS
+VISUAL_PARADIGM_PLUGIN_DIR_LINUX="/home/$USER/.config/VisualParadigm/plugins/" #Linux
 
 function readPath(){ #UNDER DEVELOPMENT
     while true; do
@@ -21,10 +31,6 @@ function readPath(){ #UNDER DEVELOPMENT
 }
 
 function get_VP_App_Path(){
-    #App Default Path
-    local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\"
-    local VISUAL_PARADIGM_APP_DIR_MAC="/Applications/Visual Paradigm.app/Contents/Resources/app/"
-    local VISUAL_PARADIGM_APP_DIR_LINUX="/home/$USER/Visual_Paradigm_17.0/"
     case "$OS" in
         Linux*)  
             while true; do
@@ -88,10 +94,6 @@ function get_VP_App_Path(){
 }
 
 function get_VP_Plugin_Path(){
-    #Plugin Default Path
-    local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS="C:\\Users\\$USER\\AppData\\Roaming\\VisualParadigm\\plugins\\" #Windows
-    local VISUAL_PARADIGM_PLUGIN_DIR_MAC="/Users/$USER/Library/Application Support/VisualParadigm/plugins/" #UNIX
-    local VISUAL_PARADIGM_PLUGIN_DIR_LINUX="/home/$USER/.config/VisualParadigm/plugins/" #UNIX
     case "$OS" in
         Linux*)  
             while true; do
@@ -178,7 +180,10 @@ function install_maven(){
                 brew install maven
             ;;
             MINGW64*)
-                echo "Installing Maven in Windows ..."
+                echo "Maven automatic installion is not supported by Windows yet."
+                echo "Follow this tutorial and try it again ..."
+                open https://phoenixnap.com/kb/install-maven-windows
+                exit 1
             ;;
         *)
             echo "Operating System not Supported"
@@ -200,7 +205,10 @@ function install_jdk(){
                 brew install java
             ;;
             MINGW64*)
-                echo "Installing Maven in Windows ..."
+                echo "Maven automatic installion is not supported by Windows yet."
+                echo "Follow this tutorial and try it again ..."
+                open https://phoenixnap.com/kb/install-java-windows
+                exit 1
             ;;
         *)
             echo "Operating System not Supported"
@@ -210,8 +218,6 @@ function install_jdk(){
 }
 
 function install_frameweb_vp_plugin(){
-    # Name of frameweb plugin
-    local frameweb_plugin_path="frameweb-vp-plugin-0.1/" #Change this line
     # Get the paths to write on pom.xml
     get_VP_App_Path
     get_VP_Plugin_Path
@@ -252,11 +258,11 @@ function install_brew(){
     if [ ! command -v brew &> /dev/null ]; then
         echo "Installing Homebrew ..."
         # if it's is not installed, then install it.
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)" 
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         # Check for what arcitecture, so you can place path.
-        if [[ "uname -m" == "x86_64" ]]; then
-            echo "export PATH=/usr/local/bin:$PATH" >> ~/.bash_profile && source ~/.bash_profile
-        fi
+        #if [[ "uname -m" == "x86_64" ]]; then
+        #    echo "export PATH=/usr/local/bin:$PATH" >> ~/.bash_profile && source ~/.bash_profile
+        #fi
     # If not
     else
         # Print that it's already installed

--- a/install.sh
+++ b/install.sh
@@ -255,7 +255,9 @@ function install_visual_paradigm(){
 
 function install_brew(){
     # Check if homebrew is installed
-    if [ ! command -v brew &> /dev/null ]; then
+    if command -v brew &> /dev/null; then
+        echo "Homebrew is already installed"
+    else  
         echo "Installing Homebrew ..."
         # if it's is not installed, then install it.
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -263,19 +265,15 @@ function install_brew(){
         #if [[ "uname -m" == "x86_64" ]]; then
         #    echo "export PATH=/usr/local/bin:$PATH" >> ~/.bash_profile && source ~/.bash_profile
         #fi
-    # If not
-    else
-        # Print that it's already installed
-        echo "Homebrew is already installed"
     fi
 }
 
 # Function to install for debian based distrOS (and ubuntu)
 function install_shell_deps(){ 
-    if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ "$OS" == "Darwin*" ]]; then
         # Instalação no Mac
         install_brew
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    elif [[ "$OS" == "Linux*" ]]; then
         # Instalação no Linux
         sudo apt-get install unzip
     fi

--- a/install.sh
+++ b/install.sh
@@ -1,35 +1,113 @@
 #!/bin/bash
 
+os=$(uname -s) # Gather OS Name
+
+function readPath(){ #UNDER DEVELOPMENT
+    while true; do
+        if [[ -d "$1" ]]; then
+            break
+        else
+            printf "<FOLDER NOT FOUND> Type a valid path!\n"
+            read -p "The path to your Visual Paradigm $2: " VISUAL_PARADIGM_APP_DIR_LINUX
+        fi
+    done
+    echo $1
+}
+
 function get_VP_App_Path(){
     #App Default Path
-    local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\"
+    local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\Program Files\Visual Paradigm CE 17.0"
     local VISUAL_PARADIGM_APP_DIR_MAC="/Applications/Visual Paradigm.app"
-    local VISUAL_PARADIGM_APP_DIR_LINUX=""
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        echo $VISUAL_PARADIGM_APP_DIR_MAC
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        echo $VISUAL_PARADIGM_APP_DIR_LINUX
-    elif [[ "$OSTYPE" == "cygwin" ]]; then
-        echo $VISUAL_PARADIGM_APP_DIR_WINDOWS
-    else
-        return 0 # Operating System not supported
-    fi
+    local VISUAL_PARADIGM_APP_DIR_LINUX="/home/$USER/Visual Paradigm CE 17.0"
+    case "$os" in
+        Linux*)  
+            while true; do
+                if [[ -d $VISUAL_PARADIGM_APP_DIR_LINUX ]]; then
+                    break
+                else
+                    printf "<FOLDER NOT FOUND> Type a valid path!\n"
+                    read -p "The path to your Visual Paradigm file is: " VISUAL_PARADIGM_APP_DIR_LINUX
+                fi
+            done
+            echo $VISUAL_PARADIGM_APP_DIR_LINUX
+        ;;
+        Darwin*)
+            while true; do
+                if [[ -d $VISUAL_PARADIGM_APP_DIR_MAC ]]; then
+                    break
+                else
+                    printf "<FOLDER NOT FOUND> Type a valid path!\n"
+                    read -p "The path to your Visual Paradigm file is: " VISUAL_PARADIGM_APP_DIR_MAC
+                fi
+            done
+            echo $VISUAL_PARADIGM_APP_DIR_MAC
+        ;;
+        CYGWIN*)
+            while true; do
+                if [[ -d $VISUAL_PARADIGM_APP_DIR_WINDOWS ]]; then
+                    break
+                else
+                    printf "<FOLDER NOT FOUND> Type a valid path!\n"
+                    read -p "The path to your Visual Paradigm file is: " VISUAL_PARADIGM_APP_DIR_WINDOWS
+                fi
+            done
+            echo $VISUAL_PARADIGM_APP_DIR_MAC
+        ;;
+        *)
+            echo "Operating System not Supported"
+            exit 1
+    esac
 }
 
 function get_VP_Plugin_Path(){
     #Plugin Default Path
-    local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS="C:\\Users\\%USERNAME%\\AppData\\Roaming\\VisualParadigm\\plugins\\"
-    local VISUAL_PARADIGM_PLUGIN_DIR_MAC="/Users/$USER/Library/Application Support/VisualParadigm/plugins/"
-    local VISUAL_PARADIGM_PLUGIN_DIR_LINUX="/home/$USER/.config/VisualParadigm/plugins/"
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        echo $VISUAL_PARADIGM_PLUGIN_DIR_MAC
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        echo $VISUAL_PARADIGM_PLUGIN_DIR_LINUX
-    elif [[ "$OSTYPE" == "cygwin" ]]; then
-        echo $VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS
-    else
-        return 0 # Operating System not supported
-    fi
+    local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS="C:\\Users\\%USERNAME%\\AppData\\Roaming\\VisualParadigm\\plugins\\" #Windows
+    local VISUAL_PARADIGM_PLUGIN_DIR_MAC="/Users/$USER/Library/Application Support/VisualParadigm/plugins/" #UNIX
+    local VISUAL_PARADIGM_PLUGIN_DIR_LINUX="/home/$USER/.config/VisualParadigm/plugins/" #UNIX
+    case "$os" in
+        Linux*)  
+            while true; do
+                #echo "Visual Paradigm Plugin Path: $VISUAL_PARADIGM_PLUGIN_DIR_LINUX"
+                read -p "Confirm (y/n)?" choice
+                case "$choice" in
+                    y|Y ) break;;
+                    n|N ) read -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_LINUX ;;
+                    * ) printf "Invalid input\n";;
+                esac
+            done
+            echo $VISUAL_PARADIGM_PLUGIN_DIR_LINUX # Return Value
+        ;;
+        Darwin*)
+            while true; do
+                echo "Visual Paradigm Plugin Path: $(VISUAL_PARADIGM_PLUGIN_DIR_LINUX)" 
+                read -p "Confirm (y/n)?" choice
+                case "$choice" in
+                    y|Y ) break;;
+                    n|N ) read -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_LINUX ;;
+                    * ) printf "Invalid input\n";;
+                esac
+            done
+            echo $VISUAL_PARADIGM_PLUGIN_DIR_LINUX # Return Value
+        ;;
+        CYGWIN*)
+            while true; do
+                echo "Visual Paradigm Plugin Path: $VISUAL_PARADIGM_PLUGIN_DIR_LINUX" 
+                read -p "Confirm (y/n)?" $answer
+                if [ "$answer" == "y" ]; then
+                    break
+                else
+                    if [[ ! -d $VISUAL_PARADIGM_PLUGIN_DIR_LINUX ]]; then
+                        printf "<FOLDER NOT FOUND> Type a valid path!\n"
+                        read -p "The path to your Visual Paradigm (PLUGIN FOLDER) is: " VISUAL_PARADIGM_PLUGIN_DIR_LINUX
+                    fi
+                fi
+            done
+            echo $VISUAL_PARADIGM_PLUGIN_DIR_LINUX # Return Value
+        ;;
+        *)
+            echo "Operating System not Supported"
+            exit 1
+    esac
 }
 
 # If the install fails, then print an error and exit.
@@ -144,10 +222,6 @@ function install_shell_deps(){
 
 # Main function
 function install_main(){ 
-    #Defining the path
-    echo "=== DEBUG MODE ==="
-    get_VP_App_Path
-    get_VP_Plugin_Path
     echo "=== Frameweb-vp-plugin Installer ==="
     echo "Installing shell dependencies ..."
     install_shell_deps || install_fail
@@ -157,6 +231,12 @@ function install_main(){
     #install_visual_paradigm || install_fail
     #echo "Installing frameweb-vp-plugin..."
     #install_frameweb_vp_plugin || install_fail
+
+
+    app_dir=$(get_VP_App_Path)
+    plugin_dir=$(get_VP_Plugin_Path)
+    echo "$app_dir"
+    echo "$plugin_dir"
 }
 
 # Run the main function

--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,7 @@ function download_plugin(){
         curl -sL $repo_url -o main.zip
         unzip main.zip
         rm -rf main.zip
+        rm -rf $repo_name-main.zip
         cd $repo_name-main
     fi
 }

--- a/install.sh
+++ b/install.sh
@@ -131,6 +131,23 @@ function get_VP_Plugin_Path(){
     esac
 }
 
+function download_plugin(){
+    local repo_name="frameweb-vp-plugin"
+    local repo_url="https://github.com/propilideno/frameweb-vp-plugin/archive/refs/heads/main.zip"
+    #repo_name_2="frameweb-vp-plugin-main"
+    echo "Downloading FrameWeb VP Plugin Repository ..."
+    if [[ "$(basename $(pwd))" == "$repo_name" ]] ; then
+        echo "FrameWeb Repository already downloaded, running the script ..."
+    else
+        echo "Downloading the FrameWeb Repository ..." 
+        rm -rf $repo_name-main
+        curl -sL $repo_url -o main.zip
+        unzip main.zip
+        rm -rf main.zip
+        cd $repo_name-main
+    fi
+}
+
 # If the install fails, then print an error and exit.
 function install_fail() {
     echo "Installation failed" 
@@ -251,6 +268,8 @@ function install_main(){
     install_jdk || install_fail
     install_maven || install_fail
     #install_visual_paradigm || install_fail
+    # Download the frameweb-vp-plugin repository
+    download_plugin
     echo "Installing frameweb-vp-plugin..."
     install_frameweb_vp_plugin || install_fail
     echo "Your app dir: $app_dir"

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,9 @@
 #!/bin/bash 
 
 function defineVPPath(){
-    #Windows path
+    #App Default Path
     local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\"
-    #MacOS path
     local VISUAL_PARADIGM_APP_DIR_MAC= "/Applications/Visual Paradigm.app"
-    #Linux path
     local VISUAL_PARADIGM_APP_DIR_DEBIAN= ""
     if [[ "$OSTYPE" == "darwin"* ]]; then
         return $VISUAL_PARADIGM_APP_DIR_MAC
@@ -13,14 +11,15 @@ function defineVPPath(){
         return $VISUAL_PARADIGM_APP_DIR_LINUX
     elif [[ "$OSTYPE" == "cygwin" ]]; then
         return $VISUAL_PARADIGM_APP_DIR_WINDOWS
+    else
+        return 0 # Operating System not supported
+    fi
 }
 
 function definePluginPath(){
-    #Windows path
+    #Plugin Default Path
     local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS= "C:\\Users\\%USERNAME%\\AppData\\Roaming\\VisualParadigm\\plugins\\"
-    #MacOS path
     local VISUAL_PARADIGM_PLUGIN_DIR_MAC= "/Users/$USER/Library/Application Support/VisualParadigm/plugins/"
-    #Linux path
     local VISUAL_PARADIGM_PLUGIN_DIR_DEBIAN= "/home/$USER/.config/VisualParadigm/plugins/"
     if [[ "$OSTYPE" == "darwin"* ]]; then
         return $VISUAL_PARADIGM_PLUGIN_DIR_MAC
@@ -28,8 +27,10 @@ function definePluginPath(){
         return $VISUAL_PARADIGM_PLUGIN_DIR_LINUX
     elif [[ "$OSTYPE" == "cygwin" ]]; then
         return $VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS
+    else
+        return 0 # Operating System not supported
+    fi
 }
-
 
 # If the install fails, then print an error and exit.
 function install_fail() {
@@ -47,7 +48,6 @@ function Help(){
 function install_maven(){
     if command -v mvn &> /dev/null; then
         echo "Maven already installed."
-        exit 1
     else
         # Instalação de dependências
         if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -59,6 +59,7 @@ function install_maven(){
         elif [[ "$OSTYPE" == "cygwin" ]]; then
             # Instalação no Windows usando Cygwin
             echo "Not supported yet"
+            exit 1
         else
             echo "Sistema operacional não suportado"
             exit 1
@@ -69,7 +70,6 @@ function install_maven(){
 function install_jdk(){
     if command -v javac &> /dev/null; then
         echo "JDK already installed."
-        exit 1
     else
         # Instalação de dependências
         if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -77,28 +77,15 @@ function install_jdk(){
             brew install java
         elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
             # Instalação no Linux
-            sudo apt-get install maven
+            sudo apt-get install default-jdk
         elif [[ "$OSTYPE" == "cygwin" ]]; then
             # Instalação no Windows
             echo "Not supported yet"
+            exit 1
         else
             echo "Sistema operacional não suportado"
             exit 1
         fi
-    fi
-}
-
-function install_jdk(){
-    echo "Instalando JDK ..."
-    if command -v javac &> /dev/null; then
-        echo "JDK already installed."
-    else
-        brew install openjdk
-        if ! command -v javac &> /dev/null; then
-            echo "O JDK não foi instalado corretamente. Verifique se há erros acima."
-            exit 1
-        fi
-        echo "O JDK foi instalado com sucesso."
     fi
 }
 
@@ -118,6 +105,7 @@ function install_frameweb_vp_plugin(){
         install_brew
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
         # Instalação no Linux
+        echo ""
     fi
 }
 
@@ -150,6 +138,7 @@ function install_shell_deps(){
         install_brew
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
         # Instalação no Linux
+        echo "No shell required dependencies on linux"
     fi
 } 
 
@@ -159,13 +148,13 @@ function install_main(){
 
     echo "=== Frameweb-vp-plugin Installer ==="
     echo "Installing shell dependencies ..."
-    install_shell_deps
+    install_shell_deps || install_fail
     echo "Installing plugin dependencies ..."
-    install_jdk
-    install_maven
-    install_visual_paradigm
+    install_jdk || install_fail
+    install_maven || install_fail
+    #install_visual_paradigm || install_fail
     echo "Installing frameweb-vp-plugin..."
-    install_frameweb_vp_plugin 
+    #install_frameweb_vp_plugin || install_fail
 }
 
 # Run the main function

--- a/install.sh
+++ b/install.sh
@@ -1,32 +1,32 @@
-#!/bin/bash 
+#!/bin/bash
 
-function defineVPPath(){
+function get_VP_App_Path(){
     #App Default Path
     local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\"
-    local VISUAL_PARADIGM_APP_DIR_MAC= "/Applications/Visual Paradigm.app"
-    local VISUAL_PARADIGM_APP_DIR_DEBIAN= ""
+    local VISUAL_PARADIGM_APP_DIR_MAC="/Applications/Visual Paradigm.app"
+    local VISUAL_PARADIGM_APP_DIR_LINUX=""
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        return $VISUAL_PARADIGM_APP_DIR_MAC
+        echo $VISUAL_PARADIGM_APP_DIR_MAC
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        return $VISUAL_PARADIGM_APP_DIR_LINUX
+        echo $VISUAL_PARADIGM_APP_DIR_LINUX
     elif [[ "$OSTYPE" == "cygwin" ]]; then
-        return $VISUAL_PARADIGM_APP_DIR_WINDOWS
+        echo $VISUAL_PARADIGM_APP_DIR_WINDOWS
     else
         return 0 # Operating System not supported
     fi
 }
 
-function definePluginPath(){
+function get_VP_Plugin_Path(){
     #Plugin Default Path
-    local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS= "C:\\Users\\%USERNAME%\\AppData\\Roaming\\VisualParadigm\\plugins\\"
-    local VISUAL_PARADIGM_PLUGIN_DIR_MAC= "/Users/$USER/Library/Application Support/VisualParadigm/plugins/"
-    local VISUAL_PARADIGM_PLUGIN_DIR_DEBIAN= "/home/$USER/.config/VisualParadigm/plugins/"
+    local VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS="C:\\Users\\%USERNAME%\\AppData\\Roaming\\VisualParadigm\\plugins\\"
+    local VISUAL_PARADIGM_PLUGIN_DIR_MAC="/Users/$USER/Library/Application Support/VisualParadigm/plugins/"
+    local VISUAL_PARADIGM_PLUGIN_DIR_LINUX="/home/$USER/.config/VisualParadigm/plugins/"
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        return $VISUAL_PARADIGM_PLUGIN_DIR_MAC
+        echo $VISUAL_PARADIGM_PLUGIN_DIR_MAC
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        return $VISUAL_PARADIGM_PLUGIN_DIR_LINUX
+        echo $VISUAL_PARADIGM_PLUGIN_DIR_LINUX
     elif [[ "$OSTYPE" == "cygwin" ]]; then
-        return $VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS
+        echo $VISUAL_PARADIGM_PLUGIN_DIR_WINDOWS
     else
         return 0 # Operating System not supported
     fi
@@ -145,7 +145,9 @@ function install_shell_deps(){
 # Main function
 function install_main(){ 
     #Defining the path
-
+    echo "=== DEBUG MODE ==="
+    get_VP_App_Path
+    get_VP_Plugin_Path
     echo "=== Frameweb-vp-plugin Installer ==="
     echo "Installing shell dependencies ..."
     install_shell_deps || install_fail
@@ -153,7 +155,7 @@ function install_main(){
     install_jdk || install_fail
     install_maven || install_fail
     #install_visual_paradigm || install_fail
-    echo "Installing frameweb-vp-plugin..."
+    #echo "Installing frameweb-vp-plugin..."
     #install_frameweb_vp_plugin || install_fail
 }
 

--- a/install.sh
+++ b/install.sh
@@ -16,42 +16,61 @@ function readPath(){ #UNDER DEVELOPMENT
 
 function get_VP_App_Path(){
     #App Default Path
-    local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\Program Files\Visual Paradigm CE 17.0"
-    local VISUAL_PARADIGM_APP_DIR_MAC="/Applications/Visual Paradigm.app"
-    local VISUAL_PARADIGM_APP_DIR_LINUX="/home/$USER/Visual Paradigm CE 17.0"
+    local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\"
+    local VISUAL_PARADIGM_APP_DIR_MAC="/Applications/Visual Paradigm.app/Contents/Resources/app/"
+    local VISUAL_PARADIGM_APP_DIR_LINUX="/home/$USER/Visual_Paradigm_CE_17.0/"
     case "$os" in
         Linux*)  
             while true; do
-                if [[ -d $VISUAL_PARADIGM_APP_DIR_LINUX ]]; then
-                    break
-                else
-                    printf "<FOLDER NOT FOUND> Type a valid path!\n"
-                    read -p "The path to your Visual Paradigm file is: " VISUAL_PARADIGM_APP_DIR_LINUX
-                fi
+                echo "Visual Paradigm Path: $VISUAL_PARADIGM_APP_DIR_LINUX"
+                read -p "Confirm (y/n)?" choice
+                case "$choice" in
+                    y|Y ) 
+                        if [[ -d $VISUAL_PARADIGM_APP_DIR_LINUX ]]; then
+                            break
+                        else
+                            printf "<FOLDER NOT FOUND> Type a valid path!\n"
+                        fi
+                    ;;
+                    n|N ) read -p "The path to your Visual Paradigm (APP FOLDER) is: " VISUAL_PARADIGM_APP_DIR_LINUX ;;
+                    * ) printf "Invalid input\n";;
+                esac
             done
-            echo $VISUAL_PARADIGM_APP_DIR_LINUX
+            app_dir=$VISUAL_PARADIGM_APP_DIR_LINUX
         ;;
         Darwin*)
             while true; do
+                echo "Visual Paradigm Path: $VISUAL_PARADIGM_APP_DIR_MAC"
+                read -p "Confirm (y/n)?" choice
+                case "$choice" in
+                    y|Y ) break;;
+                    n|N ) read -p "The path to your Visual Paradigm (APP FOLDER) is: " VISUAL_PARADIGM_APP_DIR_MAC ;;
+                    * ) printf "Invalid input\n";;
+                esac
                 if [[ -d $VISUAL_PARADIGM_APP_DIR_MAC ]]; then
                     break
                 else
                     printf "<FOLDER NOT FOUND> Type a valid path!\n"
-                    read -p "The path to your Visual Paradigm file is: " VISUAL_PARADIGM_APP_DIR_MAC
                 fi
             done
             echo $VISUAL_PARADIGM_APP_DIR_MAC
         ;;
         CYGWIN*)
             while true; do
+                echo "Visual Paradigm Path: $VISUAL_PARADIGM_APP_DIR_WINDOWS"
+                read -p "Confirm (y/n)?" choice
+                case "$choice" in
+                    y|Y ) break;;
+                    n|N ) read -p "The path to your Visual Paradigm (APP FOLDER) is: " VISUAL_PARADIGM_APP_DIR_WINDOWS ;;
+                    * ) printf "Invalid input\n";;
+                esac
                 if [[ -d $VISUAL_PARADIGM_APP_DIR_WINDOWS ]]; then
                     break
                 else
                     printf "<FOLDER NOT FOUND> Type a valid path!\n"
-                    read -p "The path to your Visual Paradigm file is: " VISUAL_PARADIGM_APP_DIR_WINDOWS
                 fi
             done
-            echo $VISUAL_PARADIGM_APP_DIR_MAC
+            echo $VISUAL_PARADIGM_APP_DIR_WINDOWS
         ;;
         *)
             echo "Operating System not Supported"
@@ -67,7 +86,7 @@ function get_VP_Plugin_Path(){
     case "$os" in
         Linux*)  
             while true; do
-                #echo "Visual Paradigm Plugin Path: $VISUAL_PARADIGM_PLUGIN_DIR_LINUX"
+                echo "Visual Paradigm Plugin Path: $VISUAL_PARADIGM_PLUGIN_DIR_LINUX"
                 read -p "Confirm (y/n)?" choice
                 case "$choice" in
                     y|Y ) break;;
@@ -75,7 +94,7 @@ function get_VP_Plugin_Path(){
                     * ) printf "Invalid input\n";;
                 esac
             done
-            echo $VISUAL_PARADIGM_PLUGIN_DIR_LINUX # Return Value
+            plugin_dir=$VISUAL_PARADIGM_PLUGIN_DIR_LINUX
         ;;
         Darwin*)
             while true; do
@@ -232,11 +251,10 @@ function install_main(){
     #echo "Installing frameweb-vp-plugin..."
     #install_frameweb_vp_plugin || install_fail
 
-
-    app_dir=$(get_VP_App_Path)
-    plugin_dir=$(get_VP_Plugin_Path)
-    echo "$app_dir"
-    echo "$plugin_dir"
+    get_VP_App_Path
+    get_VP_Plugin_Path
+    echo "Your app dir: $app_dir"
+    echo "Your plugin dir: $plugin_dir"
 }
 
 # Run the main function

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ function get_VP_App_Path(){
     #App Default Path
     local VISUAL_PARADIGM_APP_DIR_WINDOWS="C:\\Program Files\\Visual Paradigm CE 17.0\\"
     local VISUAL_PARADIGM_APP_DIR_MAC="/Applications/Visual Paradigm.app/Contents/Resources/app/"
-    local VISUAL_PARADIGM_APP_DIR_LINUX="/home/$USER/Visual_Paradigm_CE_17.0/"
+    local VISUAL_PARADIGM_APP_DIR_LINUX="/home/$USER/Visual_Paradigm_17.0/"
     case "$os" in
         Linux*)  
             while true; do
@@ -187,22 +187,23 @@ function install_jdk(){
 }
 
 function install_frameweb_vp_plugin(){
-    # Instala o plugin com o maven
-    mvn install
-    # Verificar se o plugin foi instalado com sucesso
-    if [ -d "/Users/$USER/Library/Application Support/VisualParadigm/plugins" ]; then
-        echo "O plugin foi instalado com sucesso."
+    # Name of frameweb plugin
+    local frameweb_plugin_path="frameweb-vp-plugin-0.1/" #Change this line
+    # Get the paths to write on pom.xml
+    get_VP_App_Path
+    get_VP_Plugin_Path
+    if [ -d  $plugin_dir$frameweb_plugin_path ]; then
+        echo "<WARNING> FRAMEWEB PLUGIN INSTALLED!"
+        install_fail
     else
-        echo "A instalação do plugin falhou."
-        exit 1
-    fi
 
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        # Instalação no Mac
-        install_brew
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        # Instalação no Linux
-        echo ""
+        # Config pom.xml with gathered paths
+        sed -i "s|<!-- APP_PATH -->|$app_dir|g" pom.xml
+        sed -i "s|<!-- PLUGIN_PATH -->|$plugin_dir|g" pom.xml
+        #sed -i "s|<visualparadigm.app.dir>.*</visualparadigm.app.dir>|<visualparadigm.app.dir>$app_dir</visualparadigm.app.dir>|g" pom.xml
+
+        # Install plugin with maven
+        mvn install
     fi
 }
 
@@ -248,11 +249,8 @@ function install_main(){
     install_jdk || install_fail
     install_maven || install_fail
     #install_visual_paradigm || install_fail
-    #echo "Installing frameweb-vp-plugin..."
-    #install_frameweb_vp_plugin || install_fail
-
-    get_VP_App_Path
-    get_VP_Plugin_Path
+    echo "Installing frameweb-vp-plugin..."
+    install_frameweb_vp_plugin || install_fail
     echo "Your app dir: $app_dir"
     echo "Your plugin dir: $plugin_dir"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>11</maven.compiler.release>
     <visualparadigm.app.dir>
-      /Applications/Visual Paradigm.app/Contents/Resources/app/
+      <!-- APP_PATH -->
     </visualparadigm.app.dir>
     <visualparadigm.plugin.dir>
-      /Users/vitor/Library/Application Support/VisualParadigm/plugins
+      <!-- PLUGIN_PATH -->
     </visualparadigm.plugin.dir>
   </properties>
 


### PR DESCRIPTION
# Description

### The goal of this pull request is:
- Allow the user to easy-install FrameWeb plugin for Visual Paradigm.
- Provide a better README, improving the user comprehension and affinity with our method.

# Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes are relevant to the project.

# WhoAmI
I am Propi (Lucas de Almeida), i'd contributed with Open Source Projects and with Master's degree articles. I have advanced skills in bash scripting and my changes are huge relevant for this project.
### Feel free to contact me.
- My discord: Propi#3308
- My email: contato@propi.dev

# Changes made
### About README.MD
- The `abstract` of the `README.MD` was changed to provide a better comprehension of this project.
- The `Instructions for developers` was changed to `Requirements and Installation` that should be no more only for developers and be for anyone could install with no knowledge requirement
- Added a `Full Installation with one command`, able to install FrameWeb-VP-Plugin and all requirements with **UNIX Systems**. 
- Added Requirement of Git Bash for Windows OS because our installation **requires bash**
- Added Manual Installation to allow developers to understand what is going on with installation with no knowledge in **Bash Script**
- Added Links to FrameWeb original repo, allowing users to understand the FrameWeb method.
- Separated `How to Contribute` from `README.MD` into `CONTRIBUTING.MD` because most users just want to use the tool, doesn't want contribute. If they want contribute, reading an separated folder `CONTRIBUTING.MD` will encapsulate our README.
- Added `Contributing & Ways to improve` to an fast comprehension of the project timeline. Also Added **Links to CONTRIBUTING.MD** to allow a fast travel in our repository tree.
### About Install.sh
- Verify the **default paths** to app and plugin and ask to confirm the typed path.
- Download the Frameweb-Vp-Repository and clean it after installation of plugin
- Verify **JDK** and **Maven** installation, if uninstalled the script is able to install this requirements in UNIX OS.
- In Windows, this script can open the **Tutorial** of Maven and JDK Installation.
- Can install shell requirements like **HomeBrew**
- Can modify `pom.xml` to **App dir** and **Plugin dir** given directories or default path.
- Easy-to-maintain with a lot of functions with good practices.


# Testing
Open `Git Bash` or `Terminal`, and type:
```
bash <(curl -sL https://raw.githubusercontent.com/propilideno/frameweb-vp-plugin/main/install.sh)
```

# Results
### Easy To Maintain Bash Script
![image](https://user-images.githubusercontent.com/105776775/235365036-07f53e85-af61-431d-b6e6-f35cfb5e6f3b.png)
![image](https://user-images.githubusercontent.com/105776775/235365750-871ba7c8-efb3-4b0e-b3c1-bd2c6ddc0d14.png)
### Installing Requirements
![image](https://user-images.githubusercontent.com/105776775/235364816-bdbf4e92-7b75-4552-812f-a6af3cb14224.png)
### Verifying Installation
![image](https://user-images.githubusercontent.com/105776775/235364851-5a8aa7c8-366e-4401-a4ce-3c5418152a40.png)
### Building, Installing, Cleaning and Greetings
![image](https://user-images.githubusercontent.com/105776775/235364892-6b58b6b6-4502-4a6d-8367-ab9ed06f3be4.png)